### PR TITLE
Updated Benchmark for Modern Browsers

### DIFF
--- a/benchmark/cubes.html
+++ b/benchmark/cubes.html
@@ -42,6 +42,7 @@
 		var varyFPS = targetFPS / 10;		//allowed range of FPS
 		var lowestFPS = targetFPS - varyFPS;	//lowest FPS before taking out objects
 		var startVal = 50;			//starting object number
+		var increasePerStep = 10; //number of boxes to increase per step.
 		var removeNum = startVal;		//mesh array position, for removing objects
 		var container, stats;
 		var camera, scene, renderer;
@@ -196,7 +197,10 @@
 				}
 				else if(addFlag == 1)	//add objects
 				{
-					scene.add( meshes[removeNum++] );
+					for (var i = 0; i < increasePerStep; i++)
+					{
+						scene.add( meshes[removeNum++] );
+					}
 				}
 				
 				waitFrames = waitTime;

--- a/benchmark/cubes.html
+++ b/benchmark/cubes.html
@@ -37,7 +37,7 @@
 		
 		<script>
 
-		var numObjects = 2000;			//max objects
+		var numObjects = 10000;			//max objects
 		var targetFPS = 50;			//highest fps before adding objects
 		var varyFPS = targetFPS / 10;		//allowed range of FPS
 		var lowestFPS = targetFPS - varyFPS;	//lowest FPS before taking out objects

--- a/benchmark/cubes.html
+++ b/benchmark/cubes.html
@@ -182,6 +182,11 @@
 				else if( stats.getFps() > targetFPS )	// fps too high
 				{
 					addFlag = 1;
+					
+					if (removeNum >= numObjects)
+					{
+						addFlag = 0; //We're maxed out.
+					}
 				}
 				else	//dont need to do anything
 				{
@@ -233,7 +238,15 @@
 		function updateTextBox()
 		{
 			var NumBoxes = document.getElementById('NUMBOXES_ID');
-			NumBoxes.innerHTML = "Number of boxes: " +removeNum;
+			
+			if (removeNum >= numObjects)
+			{
+				NumBoxes.innerHTML = "Number of boxes: " +numObjects + " <strong>MAXIMUM REACHED</strong><br>Please increase the benchmark's maximum object count (numObjects).";
+			}
+			else
+			{
+				NumBoxes.innerHTML = "Number of boxes: " +removeNum;
+			}
 		}
 		
 		function fpsUpdate(value)


### PR DESCRIPTION
This pull request comprises of three changes.

First, the hard upper limit of 2000 cubes is no longer sufficient for browsers on high-end computers. It has been increased to 10,000. This might need to be raised soon, but the maximum has a performance hit. I feel that it is better to raise often than add too much irrelevant overhead.

Second, the benchmark will now warn you when you have maxed out, and it will alert you of the variable to adjust. I did not add the ability to adjust the maximum dynamically from within the app. It simply alerts users that their test setup exceeds the benchmark and notifies them of the variable to change.

Third, with the cube count growing in size, I added a variable to adjust the number of cubes added per tick. By default this is 10, which means that the benchmark should complete about 10x as fast as it previously did, without sacrificing too much precision.
